### PR TITLE
Dev rs

### DIFF
--- a/src/components/locations/index.js
+++ b/src/components/locations/index.js
@@ -42,12 +42,6 @@ const LocationsCategory = ({ type, location }) => {
       <h3 className="locations-category__title" role="heading" aria-level="3">
         {type}
       </h3>
-      <button
-        aria-expanded="false"
-        className="locations-category__button js-button-expand"
-      >
-        <span>Show list</span>
-      </button>
       <ul className="locations-category__list">
         {location.map(location => (
           <li key={location.name} className="vcard locations-category__item">

--- a/src/components/nav/index.js
+++ b/src/components/nav/index.js
@@ -1,26 +1,21 @@
-import { Fragment } from 'react';
-import Link from 'next/link';
 import { withRouter } from 'next/router';
 import classnames from 'classnames';
 
 const NavItem = ({ className, title, url, pathname }) => {
   const abs = url.startsWith('http');
-  const L = abs ? Link : Fragment;
   return (
     <li className={`${className}__item`}>
-      <L href={url}>
-        <a
-          href={url}
-          className={classnames({
-            [`${className}__link`]: true,
-            [`${className}__link--selected`]: pathname === url,
-          })}
-          target={abs ? '_blank' : null}
-          rel={abs ? 'noopener' : null}
-        >
-          {title}
-        </a>
-      </L>
+      <a
+        href={url}
+        className={classnames({
+          [`${className}__link`]: true,
+          [`${className}__link--selected`]: pathname === url,
+        })}
+        target={abs ? '_blank' : null}
+        rel={abs ? 'noopener' : null}
+      >
+        {title}
+      </a>
     </li>
   );
 };

--- a/src/components/nav/index.js
+++ b/src/components/nav/index.js
@@ -1,22 +1,26 @@
+import { Fragment } from 'react';
 import Link from 'next/link';
 import { withRouter } from 'next/router';
 import classnames from 'classnames';
 
 const NavItem = ({ className, title, url, pathname }) => {
+  const abs = url.startsWith('http');
+  const L = abs ? Link : Fragment;
   return (
     <li className={`${className}__item`}>
-      <Link href={url}>
+      <L href={url}>
         <a
+          href={url}
           className={classnames({
             [`${className}__link`]: true,
-            [`${className}__link--selected`]: pathname === url
+            [`${className}__link--selected`]: pathname === url,
           })}
-          target={url.indexOf('http') === 0 ? '_blank' : null}
-          rel={url.indexOf('http') === 0 ? 'noopener' : null}
+          target={abs ? '_blank' : null}
+          rel={abs ? 'noopener' : null}
         >
           {title}
         </a>
-      </Link>
+      </L>
     </li>
   );
 };

--- a/src/components/section/section.scss
+++ b/src/components/section/section.scss
@@ -2,6 +2,10 @@
   padding-top: 96px;
   position: relative;
   z-index: 0;
+
+  &:target {
+    padding-top: 148px;
+  }
 }
 
 .section__wrapper {


### PR DESCRIPTION
- show locations in mobile view (I didn't think the button was very obvious)
- don't use `Link` in the nav header - normally we would, but since there's no JS in the final version, it simplifies the nav, but more importantly means that we can use the `:target` CSS selector (to fix the padding on the title)